### PR TITLE
Refactor raycasting to exclude non-solid blocks and increase accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.3
+- Increased the accuracy of the ray hit tests
+- Fixed the ray hit tests to no longer detect at non-solid blocks (like water) - this also fixes Riptide tridents
+
 # Version 0.3.2
 - Fixed display item for the "A true chopper arrived!" advancement
 - Fixed sound playback to no longer be global

--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,6 @@
 
 ### Enchantments for Crab Claw and Shrink Stick
 
-### Fix Raycasting
-- Raycasting also detects fluids, which is not intended
-
 ### Expand Game Content
 - More items randomly obtainable
 - More ways to get hints

--- a/raycasting/data/raycasting/function/cast_ray.mcfunction
+++ b/raycasting/data/raycasting/function/cast_ray.mcfunction
@@ -1,5 +1,5 @@
 # If the current block is not air, we hit a block
-execute unless block ~ ~ ~ air run return run function raycasting:ray_hit
+execute unless block ~ ~ ~ #raycasting:ray_hit run return run function raycasting:ray_hit
 
 # Progress the ray distance by 0.1 block
 scoreboard players add @s ray_distance 1
@@ -8,4 +8,4 @@ scoreboard players add @s ray_distance 1
 execute if score @s ray_distance > @s player_reach run return run function raycasting:ray_failed
 
 # continue the ray
-execute positioned ^ ^ ^0.1 run function raycasting:cast_ray
+execute positioned ^ ^ ^0.05 run function raycasting:cast_ray

--- a/raycasting/data/raycasting/function/start_ray.mcfunction
+++ b/raycasting/data/raycasting/function/start_ray.mcfunction
@@ -1,6 +1,6 @@
 scoreboard players set @s ray_distance 0
 
 # get the player's reach distance
-execute store result score @s player_reach run data get entity @s attributes[{id:"minecraft:player.block_interaction_range"}].base 10
+execute store result score @s player_reach run data get entity @s attributes[{id:"minecraft:player.block_interaction_range"}].base 20
 
 execute as @s at @s anchored eyes positioned ^ ^ ^ anchored feet run function raycasting:cast_ray

--- a/raycasting/data/raycasting/tags/block/ray_hit.json
+++ b/raycasting/data/raycasting/tags/block/ray_hit.json
@@ -1,0 +1,12 @@
+{
+    "replace": false,
+    "values": [
+        "air",
+        "cave_air",
+        "void_air",
+        "water",
+        "lava",
+        "fire",
+        "soul_fire"
+    ]
+}


### PR DESCRIPTION
This pull request refactors the raycasting code to improve accuracy and exclude non-solid blocks. The ray hit tests have been updated to no longer detect non-solid blocks like water, which also fixes issues with Riptide tridents.